### PR TITLE
ci: configure integration test resources

### DIFF
--- a/ci/kokoro/docker/common.cfg
+++ b/ci/kokoro/docker/common.cfg
@@ -16,3 +16,5 @@
 build_file: "google-cloud-cpp-pubsub/ci/kokoro/docker/build.sh"
 timeout_mins: 120
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/google-cloud-cpp-pubsub/pubsub-credentials.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/google-cloud-cpp-pubsub/pubsub-integration-tests-config.sh"


### PR DESCRIPTION
The code coverage build it the first build that needs the integration
test resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/18)
<!-- Reviewable:end -->
