### PR TITLE
ci: configure Windows+CMake build

### DIFF
--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -64,7 +64,7 @@ if (Test-Path env:BUILD_CACHE) {
 }
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Bootstrap vcpkg."
-# powershell -exec bypass scripts\bootstrap.ps1
+powershell -exec bypass scripts\bootstrap.ps1
 if ($LastExitCode) {
   throw "Error bootstrapping vcpkg: $LastExitCode"
   Write-Host -ForegroundColor Red "bootstrap[1] failed"

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -54,7 +54,7 @@ if (Test-Path env:RUNNING_CI) {
     # temporary files.
     $env:TEMP="T:\tmp"
 }
-ctest --output-on-failure -C $env:CONFIG
+ctest --output-on-failure -LE integration-tests -C $env:CONFIG
 if ($LastExitCode) {
     throw "ctest failed with exit code $LastExitCode"
 }

--- a/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/CONTROL
+++ b/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/CONTROL
@@ -1,0 +1,9 @@
+Source: google-cloud-cpp-common
+Version: 0.18.0
+Build-Depends: grpc, googleapis
+Description: Base C++ Libraries for Google Cloud Platform APIs
+Homepage: https://github.com/googleapis/google-cloud-cpp-common
+
+Feature: test
+Description: Build test
+Build-Depends: gtest

--- a/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/portfile.cmake
@@ -3,23 +3,27 @@ include(vcpkg_common_functions)
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO googleapis/google-cloud-cpp-common
-    REF v0.18.0
-    SHA512 030e9574b97667cf3495d206fe21fe6bdf0a2c84f31240c5cfcb82a9db6df77ccb15e000d1f1e56d8dd2a8231c97ed0d0a10c89baf147bc6408a8be2cb452f25
-    HEAD_REF master)
+  OUT_SOURCE_PATH
+  SOURCE_PATH
+  REPO
+  googleapis/google-cloud-cpp-common
+  REF
+  v0.18.0
+  SHA512
+  030e9574b97667cf3495d206fe21fe6bdf0a2c84f31240c5cfcb82a9db6df77ccb15e000d1f1e56d8dd2a8231c97ed0d0a10c89baf147bc6408a8be2cb452f25
+  HEAD_REF
+  master)
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    test BUILD_TESTING
-)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS test BUILD_TESTING)
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    DISABLE_PARALLEL_CONFIGURE
-    OPTIONS
-    ${FEATURE_OPTIONS}
-    -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF)
+  SOURCE_PATH
+  ${SOURCE_PATH}
+  PREFER_NINJA
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+  ${FEATURE_OPTIONS}
+  -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF)
 
 vcpkg_install_cmake(ADD_BIN_TO_PATH)
 
@@ -28,8 +32,8 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(
-    INSTALL ${SOURCE_PATH}/LICENSE
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp-common
-    RENAME copyright)
+  INSTALL ${SOURCE_PATH}/LICENSE
+  DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp-common
+  RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/portfile.cmake
@@ -1,0 +1,35 @@
+include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO googleapis/google-cloud-cpp-common
+    REF v0.18.0
+    SHA512 030e9574b97667cf3495d206fe21fe6bdf0a2c84f31240c5cfcb82a9db6df77ccb15e000d1f1e56d8dd2a8231c97ed0d0a10c89baf147bc6408a8be2cb452f25
+    HEAD_REF master)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    test BUILD_TESTING
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+    ${FEATURE_OPTIONS}
+    -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF)
+
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(
+    INSTALL ${SOURCE_PATH}/LICENSE
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp-common
+    RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ci/kokoro/windows/vcpkg-overlay/googleapis/CONTROL
+++ b/ci/kokoro/windows/vcpkg-overlay/googleapis/CONTROL
@@ -1,0 +1,5 @@
+Source: googleapis
+Version: 0.4.1
+Build-Depends: grpc, protobuf
+Description: C++ Proto Libraries for Google APIs.
+Homepage: https://github.com/googleapis/cpp-cmakefiles

--- a/ci/kokoro/windows/vcpkg-overlay/googleapis/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-overlay/googleapis/portfile.cmake
@@ -1,23 +1,24 @@
 include(vcpkg_common_functions)
 
-if (VCPKG_TARGET_IS_UWP)
-    message(FATAL_ERROR "Package `googleapis` doesn't support UWP")
+if(VCPKG_TARGET_IS_UWP)
+  message(FATAL_ERROR "Package `googleapis` doesn't support UWP")
 endif()
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO googleapis/cpp-cmakefiles
-    REF v0.4.1
-    SHA512 b854833b74ae10aa249ee3926f0faa766a2d9dc82283a33d21b6e933a6b1feee0b0ba711f258b2a9face0de0f4f5e7bb87230fb8dd45ba7be279903ee00c1d8a
-    HEAD_REF master
-)
+  OUT_SOURCE_PATH
+  SOURCE_PATH
+  REPO
+  googleapis/cpp-cmakefiles
+  REF
+  v0.4.1
+  SHA512
+  b854833b74ae10aa249ee3926f0faa766a2d9dc82283a33d21b6e933a6b1feee0b0ba711f258b2a9face0de0f4f5e7bb87230fb8dd45ba7be279903ee00c1d8a
+  HEAD_REF
+  master)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-)
+vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH} PREFER_NINJA)
 
 vcpkg_install_cmake(ADD_BIN_TO_PATH)
 
@@ -25,8 +26,12 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/googleapis RENAME copyright)
+file(
+  INSTALL ${SOURCE_PATH}/LICENSE
+  DESTINATION ${CURRENT_PACKAGES_DIR}/share/googleapis
+  RENAME copyright)
 
 vcpkg_copy_pdbs()
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage
+     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ci/kokoro/windows/vcpkg-overlay/googleapis/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-overlay/googleapis/portfile.cmake
@@ -1,0 +1,32 @@
+include(vcpkg_common_functions)
+
+if (VCPKG_TARGET_IS_UWP)
+    message(FATAL_ERROR "Package `googleapis` doesn't support UWP")
+endif()
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO googleapis/cpp-cmakefiles
+    REF v0.4.1
+    SHA512 b854833b74ae10aa249ee3926f0faa766a2d9dc82283a33d21b6e933a6b1feee0b0ba711f258b2a9face0de0f4f5e7bb87230fb8dd45ba7be279903ee00c1d8a
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/googleapis RENAME copyright)
+
+vcpkg_copy_pdbs()
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ci/kokoro/windows/vcpkg-overlay/googleapis/usage
+++ b/ci/kokoro/windows/vcpkg-overlay/googleapis/usage
@@ -1,0 +1,6 @@
+The package googleapis is compatible with built-in CMake targets:
+
+    find_package(googleapis CONFIG REQUIRED)
+
+    # Then link against the proto libraries that you want to use, for example:
+    target_link_libraries(main PRIVATE googleapis-c++::bigtable_protos gRPC::grpc gRPC::grpc++)

--- a/ci/kokoro/windows/vcpkg-overlay/protobuf/CONTROL
+++ b/ci/kokoro/windows/vcpkg-overlay/protobuf/CONTROL
@@ -1,0 +1,8 @@
+Source: protobuf
+Version: 3.11.3
+Homepage: https://github.com/google/protobuf
+Description: Protocol Buffers - Google's data interchange format
+
+Feature: zlib
+Description: ZLib based features like Gzip streams
+Build-Depends: zlib

--- a/ci/kokoro/windows/vcpkg-overlay/protobuf/fix-uwp.patch
+++ b/ci/kokoro/windows/vcpkg-overlay/protobuf/fix-uwp.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index f87b0928e..5102a10e3 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -190,6 +190,7 @@ if (MSVC)
+     /wd4506 # no definition for inline function 'function'
+     /wd4800 # 'type' : forcing value to bool 'true' or 'false' (performance warning)
+     /wd4996 # The compiler encountered a deprecated declaration.
++    /wd4703 # Potentially uninitialized local pointer variable 'name' used.
+   )
+   # Allow big object
+   add_definitions(/bigobj)

--- a/ci/kokoro/windows/vcpkg-overlay/protobuf/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-overlay/protobuf/portfile.cmake
@@ -1,25 +1,35 @@
 include(vcpkg_common_functions)
 
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO protocolbuffers/protobuf
-    REF v3.11.3
-    SHA512 beac21d495bfd8e9b40120d1db9fd82251958f954533fc6f76cd0b9c28f92533ac35368a4c298ebb1d8e09047b670ed3bd948bb7da6eb5cca7fdc0c1c44aa39b
-    HEAD_REF master
-    PATCHES
-        fix-uwp.patch
-)
+  OUT_SOURCE_PATH
+  SOURCE_PATH
+  REPO
+  protocolbuffers/protobuf
+  REF
+  v3.11.3
+  SHA512
+  beac21d495bfd8e9b40120d1db9fd82251958f954533fc6f76cd0b9c28f92533ac35368a4c298ebb1d8e09047b670ed3bd948bb7da6eb5cca7fdc0c1c44aa39b
+  HEAD_REF
+  master
+  PATCHES
+  fix-uwp.patch)
 
-if(CMAKE_HOST_WIN32 AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x64" AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
-    set(protobuf_BUILD_PROTOC_BINARIES OFF)
+if(CMAKE_HOST_WIN32
+   AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x64"
+   AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
+  set(protobuf_BUILD_PROTOC_BINARIES OFF)
 elseif(CMAKE_HOST_WIN32 AND VCPKG_CMAKE_SYSTEM_NAME)
-    set(protobuf_BUILD_PROTOC_BINARIES OFF)
+  set(protobuf_BUILD_PROTOC_BINARIES OFF)
 else()
-    set(protobuf_BUILD_PROTOC_BINARIES ON)
+  set(protobuf_BUILD_PROTOC_BINARIES ON)
 endif()
 
-if(NOT protobuf_BUILD_PROTOC_BINARIES AND NOT EXISTS ${CURRENT_INSTALLED_DIR}/../x86-windows/tools/protobuf)
-    message(FATAL_ERROR "Cross-targetting protobuf requires the x86-windows protoc to be available. Please install protobuf:x86-windows first.")
+if(NOT protobuf_BUILD_PROTOC_BINARIES
+   AND NOT EXISTS ${CURRENT_INSTALLED_DIR}/../x86-windows/tools/protobuf)
+  message(
+    FATAL_ERROR
+      "Cross-targetting protobuf requires the x86-windows protoc to be available. Please install protobuf:x86-windows first."
+  )
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -35,89 +45,125 @@ else()
 endif()
 
 if("zlib" IN_LIST FEATURES)
-    set(protobuf_WITH_ZLIB ON)
+  set(protobuf_WITH_ZLIB ON)
 else()
-    set(protobuf_WITH_ZLIB OFF)
+  set(protobuf_WITH_ZLIB OFF)
 endif()
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}/cmake
-    PREFER_NINJA
-    OPTIONS
-        -Dprotobuf_BUILD_SHARED_LIBS=${VCPKG_BUILD_SHARED_LIBS}
-        -Dprotobuf_MSVC_STATIC_RUNTIME=${VCPKG_BUILD_STATIC_CRT}
-        -Dprotobuf_WITH_ZLIB=${protobuf_WITH_ZLIB}
-        -Dprotobuf_BUILD_TESTS=OFF
-        -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
-        -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
-)
+  SOURCE_PATH
+  ${SOURCE_PATH}/cmake
+  PREFER_NINJA
+  OPTIONS
+  -Dprotobuf_BUILD_SHARED_LIBS=${VCPKG_BUILD_SHARED_LIBS}
+  -Dprotobuf_MSVC_STATIC_RUNTIME=${VCPKG_BUILD_STATIC_CRT}
+  -Dprotobuf_WITH_ZLIB=${protobuf_WITH_ZLIB}
+  -Dprotobuf_BUILD_TESTS=OFF
+  -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
+  -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES})
 
 vcpkg_install_cmake()
 
-# It appears that at this point the build hasn't actually finished. There is probably
-# a process spawned by the build, therefore we need to wait a bit.
+# It appears that at this point the build hasn't actually finished. There is
+# probably a process spawned by the build, therefore we need to wait a bit.
 
 function(protobuf_try_remove_recurse_wait PATH_TO_REMOVE)
+  file(REMOVE_RECURSE ${PATH_TO_REMOVE})
+  if(EXISTS "${PATH_TO_REMOVE}")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 5)
     file(REMOVE_RECURSE ${PATH_TO_REMOVE})
-    if (EXISTS "${PATH_TO_REMOVE}")
-        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 5)
-        file(REMOVE_RECURSE ${PATH_TO_REMOVE})
-    endif()
+  endif()
 endfunction()
 
 protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/include)
 
 if(CMAKE_HOST_WIN32)
-    set(EXECUTABLE_SUFFIX ".exe")
+  set(EXECUTABLE_SUFFIX ".exe")
 else()
-    set(EXECUTABLE_SUFFIX "")
+  set(EXECUTABLE_SUFFIX "")
 endif()
 
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-    file(READ ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake RELEASE_MODULE)
-    string(REPLACE "\${_IMPORT_PREFIX}/bin/protoc${EXECUTABLE_SUFFIX}" "\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}" RELEASE_MODULE "${RELEASE_MODULE}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake "${RELEASE_MODULE}")
+  file(READ
+       ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake
+       RELEASE_MODULE)
+  string(REPLACE "\${_IMPORT_PREFIX}/bin/protoc${EXECUTABLE_SUFFIX}"
+                 "\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}"
+                 RELEASE_MODULE "${RELEASE_MODULE}")
+  file(WRITE
+       ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake
+       "${RELEASE_MODULE}")
 endif()
 
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    file(READ ${CURRENT_PACKAGES_DIR}/debug/share/protobuf/protobuf-targets-debug.cmake DEBUG_MODULE)
-    string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" DEBUG_MODULE "${DEBUG_MODULE}")
-    string(REPLACE "\${_IMPORT_PREFIX}/debug/bin/protoc${EXECUTABLE_SUFFIX}" "\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}" DEBUG_MODULE "${DEBUG_MODULE}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-debug.cmake "${DEBUG_MODULE}")
+  file(READ
+       ${CURRENT_PACKAGES_DIR}/debug/share/protobuf/protobuf-targets-debug.cmake
+       DEBUG_MODULE)
+  string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" DEBUG_MODULE
+                 "${DEBUG_MODULE}")
+  string(REPLACE "\${_IMPORT_PREFIX}/debug/bin/protoc${EXECUTABLE_SUFFIX}"
+                 "\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}"
+                 DEBUG_MODULE "${DEBUG_MODULE}")
+  file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-debug.cmake
+       "${DEBUG_MODULE}")
 endif()
 
 protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/share)
 
 if(CMAKE_HOST_WIN32)
-    if(protobuf_BUILD_PROTOC_BINARIES)
-        file(INSTALL ${CURRENT_PACKAGES_DIR}/bin/protoc.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT})
-        vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
-    else()
-        file(COPY ${CURRENT_INSTALLED_DIR}/../x86-windows/tools/${PORT} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
-    endif()
+  if(protobuf_BUILD_PROTOC_BINARIES)
+    file(INSTALL ${CURRENT_PACKAGES_DIR}/bin/protoc.exe
+         DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT})
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+  else()
+    file(COPY ${CURRENT_INSTALLED_DIR}/../x86-windows/tools/${PORT}
+         DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+  endif()
 
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
-        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
-    else()
-        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin/protoc.exe)
-        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin/protoc.exe)
-    endif()
-else()
-    file(GLOB EXECUTABLES ${CURRENT_PACKAGES_DIR}/bin/protoc*)
-    foreach(E IN LISTS EXECUTABLES)
-        file(INSTALL ${E} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT}
-                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ)
-    endforeach()
-    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
+  if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
+    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
+  else()
+    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin/protoc.exe)
+    protobuf_try_remove_recurse_wait(
+      ${CURRENT_PACKAGES_DIR}/debug/bin/protoc.exe)
+  endif()
+else()
+  file(GLOB EXECUTABLES ${CURRENT_PACKAGES_DIR}/bin/protoc*)
+  foreach(E IN LISTS EXECUTABLES)
+    file(
+      INSTALL ${E}
+      DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT}
+      PERMISSIONS
+      OWNER_READ
+      OWNER_WRITE
+      OWNER_EXECUTE
+      GROUP_READ
+      GROUP_WRITE
+      GROUP_EXECUTE
+      WORLD_READ)
+  endforeach()
+  protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
+  protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    file(READ ${CURRENT_PACKAGES_DIR}/include/google/protobuf/stubs/platform_macros.h _contents)
-    string(REPLACE "\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_" "\#define PROTOBUF_USE_DLLS\n\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_" _contents "${_contents}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/include/google/protobuf/stubs/platform_macros.h "${_contents}")
+  file(READ
+       ${CURRENT_PACKAGES_DIR}/include/google/protobuf/stubs/platform_macros.h
+       _contents)
+  string(
+    REPLACE
+      "\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_"
+      "\#define PROTOBUF_USE_DLLS\n\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_"
+      _contents
+      "${_contents}")
+  file(WRITE
+       ${CURRENT_PACKAGES_DIR}/include/google/protobuf/stubs/platform_macros.h
+       "${_contents}")
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(
+  INSTALL ${SOURCE_PATH}/LICENSE
+  DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+  RENAME copyright)
 vcpkg_copy_pdbs()

--- a/ci/kokoro/windows/vcpkg-overlay/protobuf/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-overlay/protobuf/portfile.cmake
@@ -1,0 +1,123 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO protocolbuffers/protobuf
+    REF v3.11.3
+    SHA512 beac21d495bfd8e9b40120d1db9fd82251958f954533fc6f76cd0b9c28f92533ac35368a4c298ebb1d8e09047b670ed3bd948bb7da6eb5cca7fdc0c1c44aa39b
+    HEAD_REF master
+    PATCHES
+        fix-uwp.patch
+)
+
+if(CMAKE_HOST_WIN32 AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x64" AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
+    set(protobuf_BUILD_PROTOC_BINARIES OFF)
+elseif(CMAKE_HOST_WIN32 AND VCPKG_CMAKE_SYSTEM_NAME)
+    set(protobuf_BUILD_PROTOC_BINARIES OFF)
+else()
+    set(protobuf_BUILD_PROTOC_BINARIES ON)
+endif()
+
+if(NOT protobuf_BUILD_PROTOC_BINARIES AND NOT EXISTS ${CURRENT_INSTALLED_DIR}/../x86-windows/tools/protobuf)
+    message(FATAL_ERROR "Cross-targetting protobuf requires the x86-windows protoc to be available. Please install protobuf:x86-windows first.")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+  set(VCPKG_BUILD_SHARED_LIBS ON)
+else()
+  set(VCPKG_BUILD_SHARED_LIBS OFF)
+endif()
+
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+  set(VCPKG_BUILD_STATIC_CRT OFF)
+else()
+  set(VCPKG_BUILD_STATIC_CRT ON)
+endif()
+
+if("zlib" IN_LIST FEATURES)
+    set(protobuf_WITH_ZLIB ON)
+else()
+    set(protobuf_WITH_ZLIB OFF)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/cmake
+    PREFER_NINJA
+    OPTIONS
+        -Dprotobuf_BUILD_SHARED_LIBS=${VCPKG_BUILD_SHARED_LIBS}
+        -Dprotobuf_MSVC_STATIC_RUNTIME=${VCPKG_BUILD_STATIC_CRT}
+        -Dprotobuf_WITH_ZLIB=${protobuf_WITH_ZLIB}
+        -Dprotobuf_BUILD_TESTS=OFF
+        -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
+        -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
+)
+
+vcpkg_install_cmake()
+
+# It appears that at this point the build hasn't actually finished. There is probably
+# a process spawned by the build, therefore we need to wait a bit.
+
+function(protobuf_try_remove_recurse_wait PATH_TO_REMOVE)
+    file(REMOVE_RECURSE ${PATH_TO_REMOVE})
+    if (EXISTS "${PATH_TO_REMOVE}")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 5)
+        file(REMOVE_RECURSE ${PATH_TO_REMOVE})
+    endif()
+endfunction()
+
+protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/include)
+
+if(CMAKE_HOST_WIN32)
+    set(EXECUTABLE_SUFFIX ".exe")
+else()
+    set(EXECUTABLE_SUFFIX "")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(READ ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake RELEASE_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}/bin/protoc${EXECUTABLE_SUFFIX}" "\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}" RELEASE_MODULE "${RELEASE_MODULE}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake "${RELEASE_MODULE}")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/share/protobuf/protobuf-targets-debug.cmake DEBUG_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" DEBUG_MODULE "${DEBUG_MODULE}")
+    string(REPLACE "\${_IMPORT_PREFIX}/debug/bin/protoc${EXECUTABLE_SUFFIX}" "\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}" DEBUG_MODULE "${DEBUG_MODULE}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-debug.cmake "${DEBUG_MODULE}")
+endif()
+
+protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/share)
+
+if(CMAKE_HOST_WIN32)
+    if(protobuf_BUILD_PROTOC_BINARIES)
+        file(INSTALL ${CURRENT_PACKAGES_DIR}/bin/protoc.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT})
+        vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+    else()
+        file(COPY ${CURRENT_INSTALLED_DIR}/../x86-windows/tools/${PORT} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+    endif()
+
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
+        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
+    else()
+        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin/protoc.exe)
+        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin/protoc.exe)
+    endif()
+else()
+    file(GLOB EXECUTABLES ${CURRENT_PACKAGES_DIR}/bin/protoc*)
+    foreach(E IN LISTS EXECUTABLES)
+        file(INSTALL ${E} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT}
+                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ)
+    endforeach()
+    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
+    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(READ ${CURRENT_PACKAGES_DIR}/include/google/protobuf/stubs/platform_macros.h _contents)
+    string(REPLACE "\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_" "\#define PROTOBUF_USE_DLLS\n\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_" _contents "${_contents}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/include/google/protobuf/stubs/platform_macros.h "${_contents}")
+endif()
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_copy_pdbs()


### PR DESCRIPTION
Use vcpkg overlays to define our own versions of protobuf, googleapis,
and google-cloud-cpp-common, as the versions currently in vcpkg are too
old to develop Cloud Pub/Sub. As vcpkg gets recent enough versions of
these packages we can remove the overlays from our code.

This is part of the work for #12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/22)
<!-- Reviewable:end -->
