### PR TITLE
feat: capture compiler information

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -82,9 +82,16 @@ configure_file(internal/build_info.cc.in internal/build_info.cc)
 
 configure_file(version_info.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version_info.h)
 add_library(
-  googleapis_cpp_pubsub_client # cmake-format: sortable
-  ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc version.cc version.h
-  internal/build_info.h version_info.h)
+  googleapis_cpp_pubsub_client # cmake-format: sort
+  ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
+  internal/build_info.h
+  internal/compiler_info.cc
+  internal/compiler_info.h
+  internal/user_agent_prefix.cc
+  internal/user_agent_prefix.h
+  version_info.h
+  version.cc
+  version.h)
 target_include_directories(
   googleapis_cpp_pubsub_client
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -120,8 +127,10 @@ function(google_cloud_cpp_pubsub_client_define_tests)
 
   find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
-  set(googleapis_cpp_pubsub_client_unit_tests # cmake-format: sortable
-                                              internal/build_info_test.cc)
+  set(googleapis_cpp_pubsub_client_unit_tests
+      # cmake-format: sort
+      internal/build_info_test.cc internal/compiler_info_test.cc
+      internal/user_agent_prefix_test.cc)
 
   # Export the list of unit tests to a .bzl file so we do not need to maintain
   # the list in two places.

--- a/google/cloud/pubsub/googleapis_cpp_pubsub_client.bzl
+++ b/google/cloud/pubsub/googleapis_cpp_pubsub_client.bzl
@@ -17,11 +17,15 @@
 """Automatically generated source lists for googleapis_cpp_pubsub_client - DO NOT EDIT."""
 
 googleapis_cpp_pubsub_client_hdrs = [
-    "version.h",
     "internal/build_info.h",
+    "internal/compiler_info.h",
+    "internal/user_agent_prefix.h",
     "version_info.h",
+    "version.h",
 ]
 
 googleapis_cpp_pubsub_client_srcs = [
+    "internal/compiler_info.cc",
+    "internal/user_agent_prefix.cc",
     "version.cc",
 ]

--- a/google/cloud/pubsub/googleapis_cpp_pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/googleapis_cpp_pubsub_client_unit_tests.bzl
@@ -18,4 +18,6 @@
 
 googleapis_cpp_pubsub_client_unit_tests = [
     "internal/build_info_test.cc",
+    "internal/compiler_info_test.cc",
+    "internal/user_agent_prefix_test.cc",
 ]

--- a/google/cloud/pubsub/internal/compiler_info.cc
+++ b/google/cloud/pubsub/internal/compiler_info.cc
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/build_info.h"
+#include "google/cloud/internal/port_platform.h"
+#include <algorithm>
+#include <iterator>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+/**
+ * The macros for determining the compiler ID are taken from:
+ * https://gitlab.kitware.com/cmake/cmake/tree/v3.5.0/Modules/Compiler/\*-DetermineCompiler.cmake
+ * We do not care to detect every single compiler possible and only target the
+ * most popular ones.
+ *
+ * Order is significant as some compilers can define the same macros.
+ */
+std::string CompilerId() {
+#if defined(__apple_build_version__) && defined(__clang__)
+  return "AppleClang";
+#elif defined(__clang__)
+  return "Clang";
+#elif defined(__GNUC__)
+  return "GNU";
+#elif defined(_MSC_VER)
+  return "MSVC";
+#endif
+
+  return "Unknown";
+}
+
+std::string CompilerVersion() {
+  std::ostringstream os;
+
+#if defined(__apple_build_version__) && defined(__clang__)
+  os << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__
+     << "." << __apple_build_version__;
+  return std::move(os).str();
+#elif defined(__clang__)
+  os << __clang_major__ << "." << __clang_minor__ << "."
+     << __clang_patchlevel__;
+  return std::move(os).str();
+#elif defined(__GNUC__)
+  os << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
+  return std::move(os).str();
+#elif defined(_MSC_VER)
+  os << _MSC_VER / 100 << ".";
+  os << _MSC_VER % 100;
+#if defined(_MSC_FULL_VER)
+#if _MSC_VER >= 1400
+  os << "." << _MSC_FULL_VER % 100000;
+#else
+  os << "." << _MSC_FULL_VER % 10000;
+#endif
+#endif
+  return std::move(os).str();
+#endif
+
+  return "Unknown";
+}
+
+std::string CompilerFeatures() {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  return "ex";
+#else
+  return "noex";
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+std::string LanguageVersion() {
+  switch (__cplusplus) {
+    case 199711L:
+      return "1998";
+    case 201103L:
+      return "2011";
+    case 201402L:
+      return "2014";
+    case 201703L:
+      return "2017";
+    default:
+      return "unknown";
+  }
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/internal/compiler_info.h
+++ b/google/cloud/pubsub/internal/compiler_info.h
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_INTERNAL_COMPILER_INFO_H
+#define GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_INTERNAL_COMPILER_INFO_H
+
+#include "google/cloud/pubsub/version.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+/**
+ * Returns the compiler ID.
+ *
+ * The Compiler ID is a string like "GNU" or "Clang", as described by
+ * https://cmake.org/cmake/help/v3.5/variable/CMAKE_LANG_COMPILER_ID.html
+ */
+std::string CompilerId();
+
+/**
+ * Returns the compiler version.
+ *
+ * This string will be something like "9.1.1".
+ */
+std::string CompilerVersion();
+
+/**
+ * Returns certain interesting compiler features.
+ *
+ * Currently this returns one of "ex" or "noex" to indicate whether or not
+ * C++ exceptions are enabled.
+ */
+std::string CompilerFeatures();
+
+/**
+ * Returns the 4-digit year of the C++ language standard.
+ */
+std::string LanguageVersion();
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_INTERNAL_COMPILER_INFO_H

--- a/google/cloud/pubsub/internal/compiler_info_test.cc
+++ b/google/cloud/pubsub/internal/compiler_info_test.cc
@@ -1,0 +1,64 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/compiler_info.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::testing::AnyOf;
+using ::testing::ContainsRegex;
+using ::testing::Eq;
+using ::testing::MatchesRegex;
+
+TEST(CompilerInfo, CompilerId) {
+  auto cn = CompilerId();
+  EXPECT_FALSE(cn.empty());
+#ifndef _WIN32  // gMock's regex brackets don't work on Windows.
+  EXPECT_THAT(cn, ContainsRegex(R"([A-Za-z]+)"));
+#endif
+}
+
+TEST(CompilerInfo, CompilerVersion) {
+  auto cv = CompilerVersion();
+  EXPECT_FALSE(cv.empty());
+#ifndef _WIN32  // gMock's regex brackets don't work on Windows.
+  // Look for something that looks vaguely like an X.Y version number.
+  EXPECT_THAT(cv, ContainsRegex(R"([0-9]+.[0-9]+)"));
+#endif
+}
+
+TEST(CompilerInfo, CompilerFeatures) {
+  auto cf = CompilerFeatures();
+  EXPECT_FALSE(cf.empty());
+  EXPECT_THAT(cf, AnyOf(Eq("noex"), Eq("ex")));
+}
+
+TEST(CompilerInfo, LanguageVersion) {
+  auto lv = LanguageVersion();
+  EXPECT_FALSE(lv.empty());
+#ifndef _WIN32  // gMock's regex brackets don't work on Windows.
+  EXPECT_THAT(lv, MatchesRegex(R"([0-9]+)"));
+#endif
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/internal/user_agent_prefix.cc
+++ b/google/cloud/pubsub/internal/user_agent_prefix.cc
@@ -1,0 +1,22 @@
+//
+// Created by coryan on 2/6/20.
+//
+
+#include "google/cloud/pubsub/internal/user_agent_prefix.h"
+#include "google/cloud/pubsub/internal/compiler_info.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+std::string UserAgentPrefix() {
+  return "gcloud-cpp/" + google::cloud::pubsub::VersionString() + " (" +
+         CompilerId() + "-" + CompilerVersion() + "; " + CompilerFeatures() +
+         ")";
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/internal/user_agent_prefix.h
+++ b/google/cloud/pubsub/internal/user_agent_prefix.h
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_INTERNAL_USER_AGENT_PREFIX_H
+#define GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_INTERNAL_USER_AGENT_PREFIX_H
+
+#include "google/cloud/pubsub/version.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+std::string UserAgentPrefix();
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_INTERNAL_USER_AGENT_PREFIX_H

--- a/google/cloud/pubsub/internal/user_agent_prefix_test.cc
+++ b/google/cloud/pubsub/internal/user_agent_prefix_test.cc
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/user_agent_prefix.h"
+#include "google/cloud/pubsub/internal/compiler_info.h"
+#include "google/cloud/pubsub/version.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::StartsWith;
+
+TEST(UserAgentPrefix, Format) {
+  auto const actual = UserAgentPrefix();
+  EXPECT_THAT(actual, StartsWith("gcloud-cpp/"));
+  EXPECT_THAT(actual, HasSubstr(pubsub::VersionString()));
+  EXPECT_THAT(actual, HasSubstr(CompilerId()));
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Capture the compiler information to create the user-agent string.

Fixes #25 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/26)
<!-- Reviewable:end -->
