### PR TITLE
ci: enable vcpkg cache for Windows+CMake builds

### DIFF
--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -23,3 +23,16 @@ echo %date% %time%
 cd github\google-cloud-cpp-pubsub
 powershell -exec bypass ci\kokoro\windows\build.ps1
 if %errorlevel% neq 0 exit /b %errorlevel%
+
+@REM Kokoro rsyncs all the files in the %KOKORO_ARTIFACTS_DIR%, which takes a
+@REM long time. The recommended workaround is to remove all the files that are
+@REM not interesting artifacts.
+if defined KOKORO_ARTIFACTS_DIR (
+  @echo %date% %time% "Cleanup Kokoro artifacts directory"
+  cd "%KOKORO_ARTIFACTS_DIR%"
+  powershell -Command "& {Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item -Recurse -Force}"
+  if %errorlevel% neq 0 exit /b %errorlevel%
+)
+
+@echo DONE "============================================="
+@echo %date% %time%

--- a/ci/kokoro/windows/cmake-presubmit.cfg
+++ b/ci/kokoro/windows/cmake-presubmit.cfg
@@ -1,0 +1,21 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+  key: "BUILD_CACHE"
+  value: "gs://cloud-cpp-kokoro-results/build-artifacts/pubsub/windows/cmake-vcpkg-installed.zip"
+}
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/windows/cmake.cfg
+++ b/ci/kokoro/windows/cmake.cfg
@@ -1,0 +1,21 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+  key: "BUILD_CACHE"
+  value: "gs://cloud-cpp-kokoro-results/build-artifacts/pubsub/windows/cmake-vcpkg-installed.zip"
+}
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/44)
<!-- Reviewable:end -->
