### PR TITLE
ci: use clang-9.0 in most CI builds

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,8 @@
 # Disabled:
 #  -google-readability-namespace-comments the *_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
+#  -modernize-use-trailing-return-type clang-tidy aggressively recommends
+#   using `auto Foo() -> std::string { return ...; }` which does not seem right
 Checks: >
   -*,
   bugprone-*,
@@ -17,6 +19,7 @@ Checks: >
   -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
   -readability-named-parameter,
+  -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
   -readability-magic-numbers
 

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=30
+ARG DISTRO_VERSION=31
 FROM fedora:${DISTRO_VERSION}
 
 # Fedora includes packages for gRPC, libcurl, and OpenSSL that are recent enough
@@ -20,7 +20,7 @@ FROM fedora:${DISTRO_VERSION}
 # tools to compile the dependencies:
 RUN dnf makecache && \
     dnf install -y abi-compliance-checker abi-dumper \
-        clang clang-tools-extra cmake doxygen findutils gcc-c++ git \
+        clang clang-tools-extra cmake diffutils doxygen findutils gcc-c++ git \
         grpc-devel grpc-plugins libcxx-devel libcxxabi-devel libcurl-devel \
         make openssl-devel pkgconfig protobuf-compiler python-pip ShellCheck \
         tar unzip w3m wget which zlib-devel

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -74,7 +74,7 @@ if [[ "${BUILD_NAME}" = "clang-tidy" ]]; then
   # Compile with clang-tidy(1) turned on. The build treats clang-tidy warnings
   # as errors.
   export DISTRO=fedora-install
-  export DISTRO_VERSION=30
+  export DISTRO_VERSION=31
   export CC=clang
   export CXX=clang++
   export BUILD_TYPE=Debug
@@ -120,7 +120,7 @@ elif [[ "${BUILD_NAME}" = "no-exceptions" ]]; then
 elif [[ "${BUILD_NAME}" = "libcxx" ]]; then
   # Compile using libc++. This is easier to install on Fedora.
   export DISTRO=fedora-install
-  export DISTRO_VERSION=30
+  export DISTRO_VERSION=31
   export CC=clang
   export CXX=clang++
   export BAZEL_CONFIG="libcxx"
@@ -137,7 +137,7 @@ elif [[ "${BUILD_NAME}" = "msan" ]]; then
   : "${RUN_INTEGRATION_TESTS:=$DEFAULT_RUN_INTEGRATION_TESTS}"
 elif [[ "${BUILD_NAME}" = "cmake" ]]; then
   export DISTRO=fedora-install
-  export DISTRO_VERSION=30
+  export DISTRO_VERSION=31
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   export CMAKE_SOURCE_DIR="super"
@@ -167,14 +167,14 @@ elif [[ "${BUILD_NAME}" = "clang-3.8" ]]; then
 elif [[ "${BUILD_NAME}" = "cxx17" ]]; then
   export GOOGLE_CLOUD_CPP_CXX_STANDARD=17
   export DISTRO=fedora-install
-  export DISTRO_VERSION=30
+  export DISTRO_VERSION=31
   export CC=gcc
   export CXX=g++
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "coverage" ]]; then
   export BUILD_TYPE=Coverage
   export DISTRO=fedora-install
-  export DISTRO_VERSION=30
+  export DISTRO_VERSION=31
   : "${RUN_INTEGRATION_TESTS:=$DEFAULT_RUN_INTEGRATION_TESTS}"
   export RUN_SLOW_INTEGRATION_TESTS=yes
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
@@ -184,7 +184,7 @@ elif [[ "${BUILD_NAME}" = "bazel-dependency" ]]; then
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel-dependency.sh"
 elif [[ "${BUILD_NAME}" = "check-api" ]] || [[ "${BUILD_NAME}" = "update-api" ]]; then
   export DISTRO=fedora-install
-  export DISTRO_VERSION=30
+  export DISTRO_VERSION=31
   export CHECK_API=yes
   export TEST_INSTALL=yes
   export CMAKE_FLAGS=-DBUILD_SHARED_LIBS=yes


### PR DESCRIPTION
Updated the builds to use Fedora:31, which includes clang-9.0. This is
the platform we use for the clang-tidy and clang-format builds, so
effectively we updated those too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/53)
<!-- Reviewable:end -->
