### PR TITLE
cleanup: enable clang-tidy in header files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,30 @@
 ---
 # Configure clang-tidy for this project.
 
-# Disabled:
-#  -google-readability-namespace-comments the *_CLIENT_NS is a macro, and
-#   clang-tidy fails to match it against the initial value.
-#  -modernize-use-trailing-return-type clang-tidy aggressively recommends
-#   using `auto Foo() -> std::string { return ...; }` which does not seem right
+# Here is an explanation for why some of the checks are disabled:
+#
+#  -google-readability-namespace-comments: the *_CLIENT_NS is a macro, and
+#      clang-tidy fails to match it against the initial value.
+#
+#  -modernize-use-trailing-return-type: clang-tidy recommends using
+#      `auto Foo() -> std::string { return ...; }`, we think the code is less
+#      readable in this form.
+#
+#  -modernize-return-braced-init-list: We think removing typenames and using
+#      only braced-init can hurt readability.
+#
+#  -performance-move-const-arg: This warning requires the developer to
+#      know/care more about the implementation details of types/functions than
+#      should be necessary. For example, `A a; F(std::move(a));` will trigger a
+#      warning IFF `A` is a trivial type (and therefore the move is
+#      meaningless). It would also warn if `F` accepts by `const&`, which is
+#      another detail that the caller need not care about.
+#
+#  -readability-redundant-declaration: A friend declaration inside a class
+#      counts as a declaration, so if we also declare that friend outside the
+#      class in order to document it as part of the public API, that will
+#      trigger a redundant declaration warning from this check.
+#
 Checks: >
   -*,
   bugprone-*,
@@ -15,23 +34,29 @@ Checks: >
   performance-*,
   portability-*,
   readability-*,
+  -google-readability-braces-around-statements,
   -google-readability-namespace-comments,
   -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
+  -modernize-return-braced-init-list,
+  -performance-move-const-arg,
   -readability-named-parameter,
   -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
-  -readability-magic-numbers
+  -readability-redundant-declaration
 
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"
+
+# Enable clang-tidy checks in our headers.
+HeaderFilterRegex: "google/cloud/pubsub/.*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
   - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
   - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
   - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
-  - { key: readability-identifier-naming.FunctionCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,           value: aNy_CasE  }
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
   - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }
   - { key: readability-identifier-naming.ClassMemberSuffix,      value: _          }

--- a/google/cloud/pubsub/integration_tests/publisher_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/publisher_admin_integration_test.cc
@@ -27,7 +27,9 @@ namespace {
 
 std::string RandomTopic(google::cloud::internal::DefaultPRNG& generator,
                         std::string const& prefix = "cloud-cpp-testing-") {
-  return prefix + google::cloud::internal::Sample(generator, 32,
+  constexpr int kMaxRandomTopicSuffixLength = 32;
+  return prefix + google::cloud::internal::Sample(generator,
+                                                  kMaxRandomTopicSuffixLength,
                                                   "abcdefghijklmnopqrstuvwxyz");
 }
 

--- a/google/cloud/pubsub/internal/compiler_info.cc
+++ b/google/cloud/pubsub/internal/compiler_info.cc
@@ -84,14 +84,18 @@ std::string CompilerFeatures() {
 }
 
 std::string LanguageVersion() {
+  constexpr auto kMagicVersionCxx98 = 199711L;
+  constexpr auto kMagicVersionCxx11 = 201103L;
+  constexpr auto kMagicVersionCxx14 = 201402L;
+  constexpr auto kMagicVersionCxx17 = 201703L;
   switch (__cplusplus) {
-    case 199711L:
+    case kMagicVersionCxx98:
       return "1998";
-    case 201103L:
+    case kMagicVersionCxx11:
       return "2011";
-    case 201402L:
+    case kMagicVersionCxx14:
       return "2014";
-    case 201703L:
+    case kMagicVersionCxx17:
       return "2017";
     default:
       return "unknown";

--- a/google/cloud/pubsub/version.h
+++ b/google/cloud/pubsub/version.h
@@ -63,9 +63,14 @@ int constexpr VersionPatch() {
   return GOOGLE_CLOUD_CPP_PUBSUB_CLIENT_VERSION_PATCH;
 }
 
+constexpr int kMaxPatchVersions = 100;
+constexpr int kMaxMinorVersions = 100;
+
 /// A single integer representing the Major/Minor/Patch version.
 int constexpr Version() {
-  return 100 * (100 * VersionMajor() + VersionMinor()) + VersionPatch();
+  return kMaxPatchVersions *
+             (kMaxMinorVersions * VersionMajor() + VersionMinor()) +
+         VersionPatch();
 }
 
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/54)
<!-- Reviewable:end -->
