### PR TITLE
ci: fix Windows scripts to run integration tests

### DIFF
--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -59,4 +59,12 @@ if ($LastExitCode) {
     throw "ctest failed with exit code $LastExitCode"
 }
 
+if ((Test-Path env:RUN_INTEGRATION_TESTS) -and ($env:RUN_INTEGRATION_TESTS -eq "true")) {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running integration tests $env:CONFIG"
+    ctest --output-on-failure -L integration-tests
+    if ($LastExitCode) {
+        throw "Integration tests failed with exit code $LastExitCode"
+    }
+}
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DONE"

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -46,6 +46,21 @@ the KOKORO_JOB_NAME environment variable.
 "@
 }
 
+if (Test-Path env:KOKORO_GFILE_DIR) {
+    $config_file = "${env:KOKORO_GFILE_DIR}/pubsub-integration-tests-config.ps1"
+    if (Test-Path "${config_file}") {
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Loading integration tests config"
+        . "${config_file}"
+        ${env:GOOGLE_APPLICATION_CREDENTIALS}="${env:KOKORO_GFILE_DIR}/pubsub-credentials.json"
+        ${env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES}="yes"
+        (New-Object System.Net.WebClient).Downloadfile(
+            'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+             "${env:KOKORO_GFILE_DIR}/roots.pem")
+        ${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}="${env:KOKORO_GFILE_DIR}/roots.pem"
+        ${env:RUN_INTEGRATION_TESTS}="true"
+    }
+}
+
 if ($BuildName -eq "cmake") {
     $env:CONFIG = "Debug"
     $env:GENERATOR = "Ninja"

--- a/ci/kokoro/windows/common.cfg
+++ b/ci/kokoro/windows/common.cfg
@@ -16,6 +16,9 @@
 build_file: "google-cloud-cpp-pubsub/ci/kokoro/windows/build.bat"
 timeout_mins: 120
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/google-cloud-cpp-pubsub/pubsub-credentials.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/google-cloud-cpp-pubsub/pubsub-integration-tests-config.ps1"
+
 action {
   define_artifacts {
     regex: "**/win_minidumps/*.dmp"


### PR DESCRIPTION
If the configuration files for the integration tests are available the
scripts will automatically try to run these tests. Also add these files
to the Kokoro configurations.

Fixes #48 and fixes #49

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/70)
<!-- Reviewable:end -->
