### PR TITLE
ci: use `bazel fetch` to prevent flakes

### DIFF
--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -56,8 +56,10 @@ echo
 echo "================================================================"
 for repeat in 1 2 3; do
   echo "Fetch bazel dependencies at $(date) [${repeat}/3]."
-  if "${BAZEL_BIN}" fetch -- //google/cloud/...:all; then
+  if "${BAZEL_BIN}" fetch -- //google/cloud/...; then
     break;
+  else
+    echo "bazel fetch failed with $?"
   fi
 done
 

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -54,6 +54,15 @@ fi
 
 echo
 echo "================================================================"
+for repeat in 1 2 3; do
+  echo "Fetch bazel dependencies at $(date) [${repeat}/3]."
+  if "${BAZEL_BIN}" fetch -- //google/cloud/...:all; then
+    break;
+  fi
+done
+
+echo
+echo "================================================================"
 echo "Build and run unit tests at $(date)."
 "${BAZEL_BIN}" test \
     "${bazel_args[@]}" "--test_tag_filters=-integration-tests" \

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -78,8 +78,9 @@ if [[ -n "${KOKORO_GFILE_DIR:-}" ]] &&
   #    https://github.com/grpc/grpc/pull/16246
   # But it was closed without being merged, and there are open bugs:
   #    https://github.com/grpc/grpc/issues/16571
-  echo "    Getting roots.pem for gRPC."
-  wget -q https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+  echo "================================================================"
+  echo "Getting roots.pem for gRPC $(date)."
+  wget -q -c https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
   export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
 fi
 export RUN_INTEGRATION_TESTS

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -80,6 +80,7 @@ if [[ -n "${KOKORO_GFILE_DIR:-}" ]] &&
   #    https://github.com/grpc/grpc/issues/16571
   echo "================================================================"
   echo "Getting roots.pem for gRPC $(date)."
+  # Using -c (aka --continue) keeps only one copy of the downloaded file.
   wget -q -c https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
   export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
 fi

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -80,8 +80,8 @@ if [[ -n "${KOKORO_GFILE_DIR:-}" ]] &&
   #    https://github.com/grpc/grpc/issues/16571
   echo "================================================================"
   echo "Getting roots.pem for gRPC $(date)."
-  # Using -c (aka --continue) keeps only one copy of the downloaded file.
-  wget -q -c https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+  rm -f ./roots.pem
+  wget -q https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
   export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
 fi
 export RUN_INTEGRATION_TESTS


### PR DESCRIPTION
Also cleaned up the downloads for `roots.pem`. This fixes #73

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/74)
<!-- Reviewable:end -->
