### PR TITLE
chore: upgrade g-c-cpp-common to v0.19.0

### DIFF
--- a/bazel/google_cloud_cpp_pubsub_deps.bzl
+++ b/bazel/google_cloud_cpp_pubsub_deps.bzl
@@ -42,11 +42,11 @@ def google_cloud_cpp_pubsub_deps():
     if "com_github_googleapis_google_cloud_cpp_common" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp_common",
-            strip_prefix = "google-cloud-cpp-common-f4427ce3249d76465b9af18a474f7a72e8986914",
+            strip_prefix = "google-cloud-cpp-common-0.19.0",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp-common/archive/f4427ce3249d76465b9af18a474f7a72e8986914.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz",
             ],
-            sha256 = "7eff89cc22fbb6cf45905e60027e6ca7fbf966fc41c5b8eed6270e2e780dbddd",
+            sha256 = "40dc0d1465a04939bada7bab280d24ee9fe33b3370e2ab4422bb51c1ed4977c8",
         )
 
     # Load a version of googletest that we know works.

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -81,9 +81,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/f4427ce3249d76465b9af18a474f7a72e8986914.tar.gz
-RUN tar -xf f4427ce3249d76465b9af18a474f7a72e8986914.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-common-f4427ce3249d76465b9af18a474f7a72e8986914
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz
+RUN tar -xf v0.19.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.19.0
 # Compile without the tests because we are testing pubsub, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/CONTROL
+++ b/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-common
-Version: 0.18.0-2
+Version: 0.19.0
 Build-Depends: grpc, googleapis
 Description: Base C++ Libraries for Google Cloud Platform APIs
 Homepage: https://github.com/googleapis/google-cloud-cpp-common

--- a/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/portfile.cmake
@@ -8,9 +8,9 @@ vcpkg_from_github(
     REPO
     googleapis/google-cloud-cpp-common
     REF
-    f4427ce3249d76465b9af18a474f7a72e8986914
+    v0.19.0
     SHA512
-    190efd2f7de7975bbb508d204a543cfac4a57482d90d49b1c66af7a0e283ace91ec63c5390b4241045c468fbfef9353a0f20bed8e81b2ebf670b7c58d3ec33a2
+    c297cdba8f4037b19ebb92af643730a92f7a50d6341d7fbb130446c6d2c1391732fdc4ef550b95261b8decfc10d138847efa97af6f8e48968e071bc13e853684
     HEAD_REF
     master)
 

--- a/super/external/google-cloud-cpp-common.cmake
+++ b/super/external/google-cloud-cpp-common.cmake
@@ -23,10 +23,10 @@ if (NOT TARGET google-cloud-cpp-common-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp-common/archive/f4427ce3249d76465b9af18a474f7a72e8986914.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz"
     )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "7eff89cc22fbb6cf45905e60027e6ca7fbf966fc41c5b8eed6270e2e780dbddd")
+        "40dc0d1465a04939bada7bab280d24ee9fe33b3370e2ab4422bb51c1ed4977c8")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
We need this version to get `PaginationRange`.

Part of the work for #75

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/76)
<!-- Reviewable:end -->
