### PR TITLE
feat: implement wrapper for subscription names

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -101,6 +101,8 @@ add_library(
     publisher_client.h
     publisher_connection.cc
     publisher_connection.h
+    subscription.cc
+    subscription.h
     topic.cc
     topic.h
     version.cc
@@ -148,6 +150,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         internal/build_info_test.cc
         internal/compiler_info_test.cc
         internal/user_agent_prefix_test.cc
+        subscription_test.cc
         topic_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain

--- a/google/cloud/pubsub/googleapis_cpp_pubsub_client.bzl
+++ b/google/cloud/pubsub/googleapis_cpp_pubsub_client.bzl
@@ -25,6 +25,7 @@ googleapis_cpp_pubsub_client_hdrs = [
     "internal/user_agent_prefix.h",
     "publisher_client.h",
     "publisher_connection.h",
+    "subscription.h",
     "topic.h",
     "version.h",
     "version_info.h",
@@ -37,6 +38,7 @@ googleapis_cpp_pubsub_client_srcs = [
     "internal/user_agent_prefix.cc",
     "publisher_client.cc",
     "publisher_connection.cc",
+    "subscription.cc",
     "topic.cc",
     "version.cc",
 ]

--- a/google/cloud/pubsub/googleapis_cpp_pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/googleapis_cpp_pubsub_client_unit_tests.bzl
@@ -21,5 +21,6 @@ googleapis_cpp_pubsub_client_unit_tests = [
     "internal/build_info_test.cc",
     "internal/compiler_info_test.cc",
     "internal/user_agent_prefix_test.cc",
+    "subscription_test.cc",
     "topic_test.cc",
 ]

--- a/google/cloud/pubsub/subscription.cc
+++ b/google/cloud/pubsub/subscription.cc
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/subscription.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+std::string Subscription::FullName() const {
+  return "projects/" + project_id() + "/subscriptions/" + subscription_id();
+}
+
+bool operator==(Subscription const& a, Subscription const& b) {
+  return a.project_id() == b.project_id() &&
+         a.subscription_id() == b.subscription_id();
+}
+
+std::ostream& operator<<(std::ostream& os, Subscription const& rhs) {
+  return os << rhs.FullName();
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/subscription.h
+++ b/google/cloud/pubsub/subscription.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_TOPIC_H
-#define GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_TOPIC_H
+#ifndef GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_H
+#define GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_H
 
 #include "google/cloud/pubsub/version.h"
 #include <grpcpp/grpcpp.h>
@@ -24,45 +24,48 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 /**
- * Objects of this class identify a Cloud Pub/Sub topic.
+ * Objects of this class identify a Cloud Pub/Sub subscription.
  */
-class Topic {
+class Subscription {
  public:
-  Topic(std::string project_id, std::string topic_id)
-      : project_id_(std::move(project_id)), topic_id_(std::move(topic_id)) {}
+  Subscription(std::string project_id, std::string subscription_id)
+      : project_id_(std::move(project_id)),
+        subscription_id_(std::move(subscription_id)) {}
 
   /// @name Copy and move
   //@{
-  Topic(Topic const&) = default;
-  Topic& operator=(Topic const&) = default;
-  Topic(Topic&&) = default;
-  Topic& operator=(Topic&&) = default;
+  Subscription(Subscription const&) = default;
+  Subscription& operator=(Subscription const&) = default;
+  Subscription(Subscription&&) = default;
+  Subscription& operator=(Subscription&&) = default;
   //@}
 
   /// Returns the Project ID
   std::string const& project_id() const { return project_id_; }
 
-  /// Returns the Topic ID
-  std::string const& topic_id() const { return topic_id_; }
+  /// Returns the Subscription ID
+  std::string const& subscription_id() const { return subscription_id_; }
 
   /**
-   * Returns the fully qualified topic name as a string of the form:
-   * "projects/<project-id>/topics/<topic-id>"
+   * Returns the fully qualified subscription name as a string of the form:
+   * "projects/<project-id>/subscriptions/<subscription-id>"
    */
   std::string FullName() const;
 
   /// @name Equality operators
   //@{
-  friend bool operator==(Topic const& a, Topic const& b);
-  friend bool operator!=(Topic const& a, Topic const& b) { return !(a == b); }
+  friend bool operator==(Subscription const& a, Subscription const& b);
+  friend bool operator!=(Subscription const& a, Subscription const& b) {
+    return !(a == b);
+  }
   //@}
 
   /// Output the `FullName()` format.
-  friend std::ostream& operator<<(std::ostream& os, Topic const& rhs);
+  friend std::ostream& operator<<(std::ostream& os, Subscription const& rhs);
 
  private:
   std::string project_id_;
-  std::string topic_id_;
+  std::string subscription_id_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
@@ -70,4 +73,4 @@ class Topic {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_TOPIC_H
+#endif  // GOOGLE_CLOUD_CPP_PUBSUB_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_H

--- a/google/cloud/pubsub/subscription_test.cc
+++ b/google/cloud/pubsub/subscription_test.cc
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/subscription.h"
+#include <gmock/gmock.h>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+TEST(Subscription, Basics) {
+  Subscription in("p1", "s1");
+  EXPECT_EQ("p1", in.project_id());
+  EXPECT_EQ("s1", in.subscription_id());
+  EXPECT_EQ("projects/p1/subscriptions/s1", in.FullName());
+
+  auto copy = in;
+  EXPECT_EQ(copy, in);
+  EXPECT_EQ("p1", copy.project_id());
+  EXPECT_EQ("s1", copy.subscription_id());
+  EXPECT_EQ("projects/p1/subscriptions/s1", copy.FullName());
+
+  auto moved = std::move(copy);
+  EXPECT_EQ(moved, in);
+  EXPECT_EQ("p1", moved.project_id());
+  EXPECT_EQ("s1", moved.subscription_id());
+  EXPECT_EQ("projects/p1/subscriptions/s1", moved.FullName());
+
+  Subscription in2("p2", "s2");
+  EXPECT_NE(in2, in);
+  EXPECT_EQ("p2", in2.project_id());
+  EXPECT_EQ("s2", in2.subscription_id());
+  EXPECT_EQ("projects/p2/subscriptions/s2", in2.FullName());
+}
+
+TEST(Subscription, OutputStream) {
+  Subscription in("p1", "s1");
+  std::ostringstream os;
+  os << in;
+  EXPECT_EQ("projects/p1/subscriptions/s1", os.str());
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
The usual wrapper for resource names, in this case, a Cloud Pub/Sub
subscription, which should be in
`projects/<project-id>/subscriptions/<subscription-id>`
format.

Part of the work for #78 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/83)
<!-- Reviewable:end -->
