### PR TITLE
ci: update to Python 3

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -22,8 +22,8 @@ RUN dnf makecache && \
     dnf install -y abi-compliance-checker abi-dumper \
         clang clang-tools-extra cmake diffutils doxygen findutils gcc-c++ git \
         grpc-devel grpc-plugins libcxx-devel libcxxabi-devel libcurl-devel \
-        make openssl-devel pkgconfig protobuf-compiler python-pip ShellCheck \
-        tar unzip w3m wget which zlib-devel
+        make openssl-devel pkgconfig protobuf-compiler python3 python3-pip \
+        ShellCheck tar unzip w3m wget which zlib-devel
 
 # Install the the buildifier tool, which does not compile with the default
 # golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
@@ -35,8 +35,8 @@ RUN chmod 755 /usr/bin/buildifier
 # Pin this to an specific version because the formatting changes when the
 # "latest" version is updated, and we do not want the builds to break just
 # because some third party changed something.
-RUN pip install --upgrade pip
-RUN pip install cmake_format==0.6.8
+RUN pip3 install --upgrade pip
+RUN pip3 install cmake_format==0.6.8
 
 # Download and compile googletest, we need a recent version.
 WORKDIR /var/tmp/build


### PR DESCRIPTION
Use Python 3 in the builds as Python 2.7 reached EOL. We only need
Python because we reformat the CMake files using cmake-format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/93)
<!-- Reviewable:end -->
