### PR TITLE
ci: update builds to use g-c-cpp-common v0.24.0

### DIFF
--- a/bazel/google_cloud_cpp_pubsub_deps.bzl
+++ b/bazel/google_cloud_cpp_pubsub_deps.bzl
@@ -42,11 +42,11 @@ def google_cloud_cpp_pubsub_deps():
     if "com_github_googleapis_google_cloud_cpp_common" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp_common",
-            strip_prefix = "google-cloud-cpp-common-0.21.0",
+            strip_prefix = "google-cloud-cpp-common-0.24.0",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz",
             ],
-            sha256 = "2e1cd2a97122a02fe3c58a997657a360e19ec9984b857197a9a193a07b4c092b",
+            sha256 = "d5e9075dd052e4ffdeba987d9e0c5b5583312e1213d79b913f811d4d2e78caee",
         )
 
     # Load a version of googletest that we know works.

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -66,9 +66,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz
-RUN tar -xf v0.21.0.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-common-0.21.0
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz
+RUN tar -xf v0.24.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.24.0
 # Compile without the tests because we are testing pubsub, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -139,9 +139,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -118,9 +118,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -81,9 +81,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -114,9 +114,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -87,9 +87,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -134,9 +134,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -85,9 +85,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -107,9 +107,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -122,9 +122,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz && \
+    tar -xf v0.24.0.tar.gz && \
+    cd google-cloud-cpp-common-0.24.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/CONTROL
+++ b/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-common
-Version: 0.21.0
+Version: 0.24.0
 Build-Depends: grpc, googleapis
 Description: Base C++ Libraries for Google Cloud Platform APIs
 Homepage: https://github.com/googleapis/google-cloud-cpp-common

--- a/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-overlay/google-cloud-cpp-common/portfile.cmake
@@ -8,9 +8,9 @@ vcpkg_from_github(
     REPO
     googleapis/google-cloud-cpp-common
     REF
-    v0.21.0
+    v0.24.0
     SHA512
-    a339c6f57ac539f1c45f2fb92311e5d48e29a4406a1e0cfda2f1dc18e8c6db345588ad0bebd2c23531e572982d4429ee73b4f0c3df1ba8028d4100d9b12ecaa1
+    f75b8b11cad5428696c95bd1ea4cc3cb05d3e8655626ff9929ac92b4d0f23d9ad42c45b58d3641fb4077279b59fc2da7b1c5f63f7d40d8098a32209b22394fd2
     HEAD_REF
     master)
 

--- a/super/external/google-cloud-cpp-common.cmake
+++ b/super/external/google-cloud-cpp-common.cmake
@@ -23,10 +23,10 @@ if (NOT TARGET google-cloud-cpp-common-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.24.0.tar.gz"
     )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "2e1cd2a97122a02fe3c58a997657a360e19ec9984b857197a9a193a07b4c092b")
+        "d5e9075dd052e4ffdeba987d9e0c5b5583312e1213d79b913f811d4d2e78caee")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
Part of the work for googleapis/google-cloud-cpp-common#248

----
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/103)
<!-- Reviewable:end -->
