### PR TITLE
fix: copy .clang-format from spanner

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,10 +9,11 @@ PointerAlignment: Left
 
 IncludeBlocks: Merge
 IncludeCategories:
-- Regex: '^\"google/cloud/pubsub'
-  Priority: 500
-- Regex: '^\"google/cloud/'
+# Matches common headers first, but sorts them after project includes
+- Regex: '^\"google/cloud/(internal/|grpc_utils/|testing_util/|[^/]+\.h)'
   Priority: 1500
+- Regex: '^\"google/cloud/'  # project includes should sort first
+  Priority: 500
 - Regex: '^\"'
   Priority: 1000
 - Regex: '^<grpc/'


### PR DESCRIPTION
Part of googleapis/google-cloud-cpp#3596

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/105)
<!-- Reviewable:end -->
