### PR TITLE
cleanup: make unit test target names unique

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -168,9 +168,11 @@ function (google_cloud_cpp_pubsub_client_define_tests)
 
     # Generate a target for each unit test.
     foreach (fname ${googleapis_cpp_pubsub_client_unit_tests})
-        string(REPLACE "/" "_" target ${fname})
-        string(REPLACE ".cc" "" target ${target})
+        string(REPLACE "/" "_" basename ${fname})
+        string(REPLACE ".cc" "" basename ${basename})
+        set(target "pubsub_${basename}")
         add_executable(${target} ${fname})
+        set_target_properties(${target} PROPERTIES OUTPUT_NAME ${basename})
         target_link_libraries(
             ${target}
             PRIVATE googleapis-c++::pubsub_client google_cloud_cpp_testing


### PR DESCRIPTION
CMake requires target names to be unique, even in different directories.
Fortunately the target name can be different from the binary name,
though it requires a little more work to make it so. Unit tests are more
likely to repeat names, so use a prefix to minimize the possibility of
collisions. The other targets can be handled on a ad-hoc basis when and
if we have a target name collision.

Part of the work for googleapis/google-cloud-cpp#3548

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-pubsub/110)
<!-- Reviewable:end -->
